### PR TITLE
use a single worker when running the publishers since these could fai…

### DIFF
--- a/backend-rails/app/admin/publish_job.rb
+++ b/backend-rails/app/admin/publish_job.rb
@@ -29,7 +29,7 @@ ActiveAdmin.register PublishJob do
       publish_job.update(webhook_url: ENV['BJ_DISCORD_WEBHOOK']) if publish_job.platform == 'discord'
 
       puts "Trying to publish episode #{publish_job.podcast_episode.title} to: #{publish_job.platform}"
-      ManualEpisodePublisherWorker.perform_async(current_admin_user.id, publish_job.id)
+      SingleEpisodePublisherWorker.perform_async(current_admin_user.id, publish_job.id)
     end
 
     def permitted_params

--- a/backend-rails/app/services/last_podcast_episode_publisher_service.rb
+++ b/backend-rails/app/services/last_podcast_episode_publisher_service.rb
@@ -9,9 +9,8 @@ class LastPodcastEpisodePublisherService
     discord: ENV['BJ_DISCORD_WEBHOOK']
   }.freeze
 
-  def initialize(rss_reader = nil, podcast_episode_publisher = nil)
+  def initialize(rss_reader = nil)
     @rss_reader = rss_reader || Rss::ReaderService.new
-    @podcast_episode_publisher = podcast_episode_publisher || PodcastEpisodePublisherService.new
   end
 
   def call
@@ -32,7 +31,7 @@ class LastPodcastEpisodePublisherService
                                       podcast_episode: episode,
                                       webhook_url: PUBLISH_CONFIG[platform])
 
-      @podcast_episode_publisher.call(admin_user, publish_job)
+      SingleEpisodePublisherWorker.perform_async(admin_user.id, publish_job.id)
     end
   end
 

--- a/backend-rails/app/workers/single_episode_publisher_worker.rb
+++ b/backend-rails/app/workers/single_episode_publisher_worker.rb
@@ -1,4 +1,4 @@
-class ManualEpisodePublisherWorker
+class SingleEpisodePublisherWorker
   include Sidekiq::Worker
   sidekiq_options retry: false
 

--- a/backend-rails/config/schedule.yml
+++ b/backend-rails/config/schedule.yml
@@ -1,6 +1,6 @@
 # config/schedule.yml
 batos_jugando_tweets:
-  cron: "*/30 * * * *" # run each 30 minutes
+  cron: "*/15 * * * *" # run each 15 minutes
   class: "TwitterReaderWorker"
 el_hongo_verde_publisher:
   cron: "0 17 * * *"


### PR DESCRIPTION
…l separated